### PR TITLE
Add color to amount placeholder Text

### DIFF
--- a/src/components/Utils.js
+++ b/src/components/Utils.js
@@ -160,7 +160,9 @@ Label.propTypes = {
   color: PropTypes.string.isRequired
 }
 
-export const FormInput = styled.TextInput`
+export const FormInput = styled.TextInput.attrs({
+  placeholderTextColor: Colors.primaryText
+})`
   color: ${Colors.primaryText};
   padding: ${props => props.padding}px;
   font-size: ${FontSize['small']};


### PR DESCRIPTION
The placeholder text in Participate Scene's amount text input was too dark to see properly. Changed it in Utils styled-component's file. 