### PR TITLE
:sparkles: Adding rewards flow on signup

### DIFF
--- a/src/scenes/Login/index.js
+++ b/src/scenes/Login/index.js
@@ -13,7 +13,6 @@ import { StackActions, NavigationActions } from 'react-navigation'
 import * as Utils from '../../components/Utils'
 import { Colors, Spacing } from '../../components/DesignSystem'
 import ButtonGradient from '../../components/ButtonGradient'
-import { createUserKeyPair } from '../../utils/secretsUtils'
 import { checkPublicKeyReusability } from '../../utils/userAccountUtils'
 import { version } from '../../../package.json'
 

--- a/src/scenes/Rewards/index.js
+++ b/src/scenes/Rewards/index.js
@@ -3,34 +3,46 @@ import PropTypes from 'prop-types'
 import { ImageBackground } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import Ionicons from 'react-native-vector-icons/Ionicons'
+import { StackActions, NavigationActions } from 'react-navigation'
+
 import * as Utils from '../../components/Utils'
 import { Colors, Spacing } from '../../components/DesignSystem'
 
 class RewardsScreen extends PureComponent {
+
+  _navigateHome = () => {
+    const { navigation } = this.props
+    const navigateToHome = StackActions.reset({
+      index: 0,
+      actions: [NavigationActions.navigate({ routeName: 'App' })],
+      key: null
+    })
+    navigation.dispatch(navigateToHome)
+  }
 
   render() {
     const { label, amount, token } = this.props.navigation.state.params
 
     return (
       <Utils.Container align='stretch'>
-        <LinearGradient 
-          start={{x: 0, y: 0}} 
-          end={{x: 1, y: 1}} 
-          colors={[Colors.primaryGradient[0], Colors.primaryGradient[1]]} 
-          style={{flex: 1, width: '100%', alignItems: 'center', justifyContent: 'center'}}
+        <LinearGradient
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          colors={[Colors.primaryGradient[0], Colors.primaryGradient[1]]}
+          style={{ flex: 1, width: '100%', alignItems: 'center', justifyContent: 'center' }}
         >
-          <Utils.View 
-            align='center' 
-            justify='center' 
-            width={450} 
-            height={450} 
+          <Utils.View
+            align='center'
+            justify='center'
+            width={450}
+            height={450}
             position='relative'
           >
-            <Utils.Img 
-              source={require('../../assets/tron-logo-small.png')} 
+            <Utils.Img
+              source={require('../../assets/tron-logo-small.png')}
               position='absolute'
               top='0'
-              width='42px' 
+              width='42px'
               height='42px'
             />
             <Utils.Text
@@ -42,25 +54,25 @@ class RewardsScreen extends PureComponent {
               source={require('../../assets/circle-illustration.png')}
               resizeMode='contain'
               paddingSize='none'
-              style={{flex: 1, paddingTop: 50}}
+              style={{ flex: 1, paddingTop: 50 }}
             >
-              <Utils.View 
+              <Utils.View
                 align='center'
                 justify='center'
               >
                 <ImageBackground
                   source={require('../../assets/bg-account.png')}
-                  style={{width: 300, height: 300}}
+                  style={{ width: 300, height: 300 }}
                 >
                   <Utils.View
                     marginTop={65}
                     align='center'
                   >
-                    <Utils.Text 
+                    <Utils.Text
                       font='light'
                       align='center'
                       size='average'
-                    >{label}</Utils.Text> 
+                    >{label}</Utils.Text>
                     <Utils.Text
                       align='center'
                       size='xsmall'
@@ -72,12 +84,12 @@ class RewardsScreen extends PureComponent {
                       marginY={15}
                     >{amount}</Utils.Text>
                     <Utils.View
-                        backgroundColor={Colors.primaryText}
-                        borderRadius={3}
-                        width={65}
-                        padding={8} 
-                        elevation={5} 
-                        style={{shadowOffset: {  width: 15,  height: 15,  }, shadowColor: 'black', shadowRadius: 15, shadowOpacity: 0.5}}>
+                      backgroundColor={Colors.primaryText}
+                      borderRadius={3}
+                      width={65}
+                      padding={8}
+                      elevation={5}
+                      style={{ shadowOffset: { width: 15, height: 15, }, shadowColor: 'black', shadowRadius: 15, shadowOpacity: 0.5 }}>
                       <Utils.Text
                         size='smaller'
                         align='center'
@@ -89,21 +101,21 @@ class RewardsScreen extends PureComponent {
               </Utils.View>
             </ImageBackground>
           </Utils.View>
-            <Utils.ContentWithBackground
-              source={require('../../assets/back-arrow-bg.png')}
-              resizeMode='contain'
-              justify='center'
-              align='center'
-              position='absolute'
-              bottom={25}
-              right={25}
-              width={120}
-              height={120}
-            >
-              <Utils.ButtonWrapper onPress={() => {}}>
-                <Ionicons name='ios-arrow-round-forward' size={Spacing.large} color={Colors.primaryText} />
-              </Utils.ButtonWrapper>
-            </Utils.ContentWithBackground>
+          <Utils.ContentWithBackground
+            source={require('../../assets/back-arrow-bg.png')}
+            resizeMode='contain'
+            justify='center'
+            align='center'
+            position='absolute'
+            bottom={25}
+            right={25}
+            width={120}
+            height={120}
+          >
+            <Utils.ButtonWrapper onPress={this._navigateHome}>
+              <Ionicons name='ios-arrow-round-forward' size={Spacing.large} color={Colors.primaryText} />
+            </Utils.ButtonWrapper>
+          </Utils.ContentWithBackground>
         </LinearGradient>
       </Utils.Container>
     )

--- a/src/scenes/Seed/Restore.js
+++ b/src/scenes/Seed/Restore.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { SafeAreaView, Alert } from 'react-native'
+import { SafeAreaView, Alert, Keyboard } from 'react-native'
 import { StackActions, NavigationActions } from 'react-navigation'
 
 import * as Utils from '../../components/Utils'
@@ -7,7 +7,6 @@ import { Colors } from '../../components/DesignSystem'
 import ButtonGradient from '../../components/ButtonGradient'
 
 import { recoverUserKeypair } from '../../utils/secretsUtils'
-import { resetWalletData } from '../../utils/userAccountUtils'
 import { Context } from '../../store/context'
 
 class Restore extends React.Component {
@@ -51,10 +50,10 @@ class Restore extends React.Component {
 
   _restoreWallet = async () => {
     const { updateWalletData } = this.props.context
+    Keyboard.dismiss()
     this.setState({ loading: true })
     try {
       await recoverUserKeypair(this.state.seed)
-      await resetWalletData()
       await updateWalletData()
       alert("Wallet recovered with success!")
       this.setState({ loading: false }, () => {

--- a/src/scenes/Seed/RestoreOrCreateSeed.js
+++ b/src/scenes/Seed/RestoreOrCreateSeed.js
@@ -5,7 +5,6 @@ import * as Utils from '../../components/Utils'
 import ButtonGradient from '../../components/ButtonGradient'
 
 import { createUserKeyPair } from '../../utils/secretsUtils'
-import { resetWalletData } from '../../utils/userAccountUtils'
 
 class RestoreOrCreateSeed extends React.Component {
   static navigationOptions = {
@@ -24,7 +23,6 @@ class RestoreOrCreateSeed extends React.Component {
   _newWallet = async () => {
     this.setState({ loading: true })
     await this._createKeyPair()
-    await resetWalletData()
     this.setState({ loading: false })
     this.props.navigation.navigate('SeedCreate')
   }

--- a/src/scenes/Signup/ConfirmSignup.js
+++ b/src/scenes/Signup/ConfirmSignup.js
@@ -50,7 +50,6 @@ class SignupScene extends Component {
         throw new Error('User already gifted')
       }
     } catch (error) {
-      console.warn(error)
       const navigateToHome = StackActions.reset({
         index: 0,
         actions: [NavigationActions.navigate({ routeName: 'App' })],

--- a/src/scenes/Signup/ConfirmSignup.js
+++ b/src/scenes/Signup/ConfirmSignup.js
@@ -10,7 +10,9 @@ import * as Utils from '../../components/Utils'
 import { Colors, Spacing } from '../../components/DesignSystem'
 
 //Services
-import { createUserKeyPair } from '../../utils/secretsUtils';
+import { createUserKeyPair, getUserSecrets } from '../../utils/secretsUtils';
+import WalletClient from '../../services/client';
+import { getUserPublicKey } from '../../utils/userAccountUtils';
 
 class SignupScene extends Component {
   state = {
@@ -30,6 +32,34 @@ class SignupScene extends Component {
     alert("We created a secret list of words for you. We highly recommend that you write it down on paper to be able to recover it later.")
   }
 
+
+  _navigateNext = async () => {
+    const { navigation } = this.props
+    try {
+      const result = await WalletClient.giftUser()
+      if (result) {
+        const address = await getUserPublicKey()
+        //Adapt Reward here
+        const rewardsParams = {
+          label: address,
+          amount: 1,
+          token: 'TWX',
+        }
+        navigation.navigate('Rewards', rewardsParams)
+      } else {
+        throw new Error('User already gifted')
+      }
+    } catch (error) {
+      console.warn(error)
+      const navigateToHome = StackActions.reset({
+        index: 0,
+        actions: [NavigationActions.navigate({ routeName: 'App' })],
+        key: null
+      })
+      navigation.dispatch(navigateToHome)
+    }
+  }
+
   confirmSignup = async () => {
     const { code } = this.state
     const { navigation } = this.props
@@ -42,14 +72,9 @@ class SignupScene extends Component {
       await Auth.confirmSignUp(username, code)
       await Auth.signIn(username, password)
       await this._createKeyPair()
-
       this.setState({ loadingConfirm: false })
-      const confirmSignAndLogin = StackActions.reset({
-        index: 0,
-        actions: [NavigationActions.navigate({ routeName: 'App' })],
-        key: null
-      })
-      navigation.dispatch(confirmSignAndLogin)
+      await this._navigateNext()
+
     } catch (error) {
       if (error.code === 'NotAuthorizedException') {
         this.setState({ loadingConfirm: false, confirmError: 'Incorrect credentials, try again..' })

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -88,6 +88,30 @@ class ClientWallet {
   }
 
   //*============TronWalletServerless Api============*//
+
+  async giftUser() {
+    try {
+      const { signInUserSession, username } = await Auth.currentAuthenticatedUser()
+      const authToken = signInUserSession.idToken.jwtToken
+      const address = await getUserPublicKey()
+
+      const config = {
+        headers: {
+          "Authorization": authToken
+        }
+      }
+      const body = {
+        address,
+        username,
+      }
+
+      const { data: { result } } = await axios.post(`${this.tronwalletApi}/gift`, body, config)
+      return result
+    } catch (error) {
+      throw error
+    }
+  }
+
   async getAssetList() {
     try {
       const { nodeIp } = await NodesIp.getAllNodesIp()

--- a/src/utils/secretsUtils.js
+++ b/src/utils/secretsUtils.js
@@ -3,6 +3,7 @@ import DeviceInfo from 'react-native-device-info'
 
 import getSecretsStore from '../store/secrets'
 import Client from '../services/client'
+import { resetWalletData } from './userAccountUtils';
 
 export const createUserKeyPair = async () => {
     try {
@@ -30,6 +31,7 @@ const generateKeypair = async (mnemonic, randomlyGenerated) => {
     const secretsStore = await getSecretsStore()
     await secretsStore.write(() => secretsStore.create('Secrets', generatedKeypair, true))
     await Client.setUserPk(generatedKeypair.address)
+    await resetWalletData()
 }
 
 export const confirmSecret = async () => {


### PR DESCRIPTION
Added rewards flow to the signup flow where if user create a new account it gets 1 TWX as a reward. Centralizing resetWalletData at generatedKeypair because it makes sense delete data when user creates a new keypair at the app.

#56 