### PR TITLE
Search vote screen improvements

### DIFF
--- a/src/scenes/Vote/index.js
+++ b/src/scenes/Vote/index.js
@@ -317,7 +317,7 @@ class VoteScene extends PureComponent {
   }
 
   render() {
-    const { totalVotes, totalRemaining, votesError } = this.state
+    const { totalVotes, totalRemaining, votesError, refreshing, loadingList } = this.state
     return (
       <Utils.Container>
         {(totalVotes !== null && totalRemaining !== null) && (
@@ -380,7 +380,7 @@ class VoteScene extends PureComponent {
               onEndReachedThreshold={0.5}
               onEndReached={this._loadMoreCandidates}
               onRefresh={this._refreshCandidates}
-              refreshing={this.state.refreshing}
+              refreshing={refreshing || loadingList}
               removeClippedSubviews
             />
           </FadeIn>

--- a/src/scenes/Vote/index.js
+++ b/src/scenes/Vote/index.js
@@ -371,18 +371,20 @@ class VoteScene extends PureComponent {
             marginTop={0}
           />
         </Utils.Content>
-        <FadeIn name='candidates'>
-          <FlatList
-            keyExtractor={item => item.address}
-            data={this.state.voteList}
-            renderItem={this._renderRow}
-            onEndReachedThreshold={0.5}
-            onEndReached={this._loadMoreCandidates}
-            onRefresh={this._refreshCandidates}
-            refreshing={this.state.refreshing}
-            removeClippedSubviews
-          />
-        </FadeIn>
+        <Utils.Content flex={1}>
+          <FadeIn name='candidates'>
+            <FlatList
+              keyExtractor={item => item.address}
+              data={this.state.voteList}
+              renderItem={this._renderRow}
+              onEndReachedThreshold={0.5}
+              onEndReached={this._loadMoreCandidates}
+              onRefresh={this._refreshCandidates}
+              refreshing={this.state.refreshing}
+              removeClippedSubviews
+            />
+          </FadeIn>
+        </Utils.Content>
       </Utils.Container>
     )
   }

--- a/src/scenes/Vote/index.js
+++ b/src/scenes/Vote/index.js
@@ -1,6 +1,6 @@
 // Dependencies
 import React, { PureComponent } from 'react'
-import { forIn, reduce, union, clamp } from 'lodash'
+import { forIn, reduce, union, clamp, debounce } from 'lodash'
 import { Linking, FlatList } from 'react-native'
 import qs from 'qs'
 
@@ -54,6 +54,7 @@ class VoteScene extends PureComponent {
   async componentDidMount() {
     this.didFocusSubscription = this.props.navigation.addListener('didFocus', this._loadData)
     this.dataSubscription = setInterval(this._loadData, POOLING_TIME)
+    this._onSearch = debounce(this._onSearch, 500)
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fix the followings cards:
- [Debounce search on vote scene](https://trello.com/c/SkRPUDcU/276-debounce-search-on-vote-scene)
- [Last items from votes scene aren't visible](https://trello.com/c/CaxzSlJi/268-last-items-from-votes-scene-arent-visible)

There is [another card](https://trello.com/c/E0VmlImk/272-warnings-on-search-votes-scene) related to this screen, but I was not ablet to replicate it.