### PR TITLE
[WIP] Improving transfer screen user xp

### DIFF
--- a/src/components/Utils.js
+++ b/src/components/Utils.js
@@ -494,6 +494,10 @@ InputError.defaultProps = {
   marginBottom: Spacing.small
 }
 
+export const Warning = Error.extend`
+  color: ${Colors.orange};
+`
+
 export const PasteButton = styled.TouchableOpacity`
   margin-horizontal: 5px;
   /* padding: ${Spacing.medium - 5}px; */

--- a/src/scenes/Send/index.js
+++ b/src/scenes/Send/index.js
@@ -34,20 +34,21 @@ class SendScene extends Component {
     token: 'TRX',
     balances: [],
     error: null,
+    warning: null,
     loadingSign: false,
     loadingData: true,
     trxBalance: 0.0,
     QRModalVisible: false
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this._navListener = this.props.navigation.addListener(
       'didFocus',
       this.loadData
     )
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this._navListener.remove()
   }
 
@@ -66,7 +67,8 @@ class SendScene extends Component {
         from: userPublicKey,
         balances,
         loadingData: false,
-        trxBalance: balance
+        trxBalance: balance,
+        warning: balance === 0 ? 'NO BALANCE' : null
       })
     } catch (error) {
       Alert.alert('Error while getting balance data')
@@ -195,7 +197,7 @@ class SendScene extends Component {
           leftIcon={
             <Ionicons name='md-menu' color={Colors.primaryText} size={24} />
           }
-          onLeftPress={() => {}}
+          onLeftPress={() => { }}
           rightIcon={
             <Ionicons name='ios-close' color={Colors.primaryText} size={40} />
           }
@@ -232,8 +234,8 @@ class SendScene extends Component {
     </React.Fragment>
   )
 
-  render () {
-    const { loadingSign, loadingData, error, to, trxBalance, amount } = this.state
+  render() {
+    const { loadingSign, loadingData, error, warning, to, trxBalance, amount } = this.state
     return (
       <KeyboardAvoidingView
         style={{ flex: 1, backgroundColor: Colors.background }}
@@ -261,10 +263,11 @@ class SendScene extends Component {
                     <Utils.Text size='small'>TRX</Utils.Text>
                   </Utils.View>
                 </Utils.Row>
+                {warning && <Utils.Warning>{warning}</Utils.Warning>}
               </Utils.View>
             </Header>
             <Utils.Content>
-            <ModalSelector
+              <ModalSelector
                 data={this.state.balances.map(item => ({
                   key: item.name,
                   label: item.name
@@ -310,14 +313,14 @@ class SendScene extends Component {
               {loadingSign || loadingData ? (
                 <ActivityIndicator size='small' color={Colors.primaryText} />
               ) : (
-                <ButtonGradient
-                  text='SEND'
-                  onPress={this.submit}
-                  size='medium'
-                  marginVertical='large'
+                  <ButtonGradient
+                    text='SEND'
+                    onPress={this.submit}
+                    size='medium'
+                    marginVertical='large'
                     disabled={trxBalance === 0}
-                />
-              )}
+                  />
+                )}
               <Utils.VerticalSpacer />
             </Utils.Content>
           </Utils.Container>

--- a/src/scenes/Send/index.js
+++ b/src/scenes/Send/index.js
@@ -270,6 +270,7 @@ class SendScene extends Component {
                   label: item.name
                 }))}
                 onChange={option => this.setState({ token: option.label })}
+                disabled={trxBalance === 0}
               >
                 <Input
                   label='TOKEN'
@@ -314,6 +315,7 @@ class SendScene extends Component {
                   onPress={this.submit}
                   size='medium'
                   marginVertical='large'
+                    disabled={trxBalance === 0}
                 />
               )}
               <Utils.VerticalSpacer />


### PR DESCRIPTION
Related Trello card:
- [x] [Empty seletor on send, when zero balance. Disable when balance is zero](https://trello.com/c/lz1KmEHo/290-empty-seletor-on-send-when-zero-balance-disable-when-balance-is-zero)
- [ ] [Add signup screen input focus functionality to Freeze/Send Screens.](https://trello.com/c/YgCo4f5d/287-add-signup-screen-input-focus-functionality-to-freeze-send-screens)
- [ ] [Add safe area view to qrcode scan modal on send scene](https://trello.com/c/Pz8MHK9S/269-add-safe-area-view-to-qrcode-scan-modal-on-send-scene)