### PR TITLE
make participate come with tokenName

### DIFF
--- a/src/scenes/Transactions/index.js
+++ b/src/scenes/Transactions/index.js
@@ -92,7 +92,8 @@ class TransactionsScene extends Component {
           if (item.type === 'Participate') {
             transaction.contractData = {
               ...transaction.contractData,
-              transferFromAddress: item.contractData.toAddress
+              transferFromAddress: item.contractData.toAddress,
+              tokenName: item.contractData.token
             }
           }
           store.create('Transaction', transaction, true)


### PR DESCRIPTION
Make participate transactions come with Token Name so that they don't get listed as 120 null, for instance.