### PR TITLE
remove delete account button from account edit form

### DIFF
--- a/src/scenes/EditAddressBookItem/index.js
+++ b/src/scenes/EditAddressBookItem/index.js
@@ -26,7 +26,7 @@ class EditContact extends Component {
 
     return (
       <React.Fragment>
-        <NavigationHeader title={tl.t('addressBook.shared.edit')} onBack={() => navigation.goBack()} rightButton={(
+        <NavigationHeader title={tl.t('addressBook.shared.edit')} onBack={() => navigation.goBack()} rightButton={isUserAccount ? null : (
           <ClearButton onPress={() => {
             Alert.alert(
               tl.t('addressBook.contacts.delete.title'),


### PR DESCRIPTION
There was still a delete account button hidden in the edit form. This PR will remove it.